### PR TITLE
Change query id

### DIFF
--- a/doc/system_tour.asciidoc
+++ b/doc/system_tour.asciidoc
@@ -110,7 +110,7 @@ button, you should get the following response:
   "data": {
     "node": {
       "climate": "arid",
-      "id": "cGxhbmV0OjE=",
+      "id": "UGxhbmV0OjE=",
       "name": "Tatooine"
     }
   }


### PR DESCRIPTION
The response should return the same id used at the query definition.