### PR TITLE
Typo

### DIFF
--- a/doc/getting_started.asciidoc
+++ b/doc/getting_started.asciidoc
@@ -202,7 +202,7 @@ Eshell V8.3  (abort with ^G)
 <3> Run the Erlang interpreter with an altered path for our newly compiled modules
 <4> Create the schema
 
-The call the `create_schema()` runs the following schema creation code:
+The call `create_schema()` runs the following schema creation code:
 
 [source,erlang]
 ----


### PR DESCRIPTION
A better change might be:
The call to create_schema()